### PR TITLE
Update example/with-material-ui broken links

### DIFF
--- a/examples/with-material-ui/README.md
+++ b/examples/with-material-ui/README.md
@@ -2,5 +2,5 @@
 
 **Note:** These examples are maintained outside of the Next.js repository:
 
-1. Official [TypeScript example](https://github.com/mui/material-ui/tree/master/examples/material-next-ts)
-2. Official [JavaScript example](https://github.com/mui/material-ui/tree/master/examples/material-next)
+1. Official [TypeScript example](https://github.com/mui/material-ui/tree/master/examples/material-ui-nextjs-ts)
+2. Official [JavaScript example](https://github.com/mui/material-ui/tree/master/examples/material-ui-nextjs)


### PR DESCRIPTION
Fixed the example/with-material-ui broken links.

It seems the external websites got updated.

